### PR TITLE
[GitHub jobs] Location from API

### DIFF
--- a/legacy/github-jobs/README.md
+++ b/legacy/github-jobs/README.md
@@ -60,6 +60,8 @@ or Vue. Don’t look at the existing solution. Fulfill user stories below:
 - [@material-design-icons/font](https://marella.me/material-design-icons/demo/font/)
 - [SerpApi Goggle Jobs API](https://serpapi.com/google-jobs-api)
 - [Weather API](https://www.weatherapi.com/)
+- [ipquery](https://ipquery.io/) instead of [Geolocation
+  API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation)
 
 ### Extra features
 

--- a/legacy/github-jobs/package.json
+++ b/legacy/github-jobs/package.json
@@ -24,7 +24,6 @@
     "@hrc/toggle-theme": "catalog:",
     "@lib/components": "workspace:*",
     "@lib/fetcher": "workspace:*",
-    "@lib/geolocation": "workspace:*",
     "@lib/sass-utils": "workspace:*",
     "@material-design-icons/font": "catalog:",
     "astro": "catalog:",

--- a/legacy/github-jobs/src/config.ts
+++ b/legacy/github-jobs/src/config.ts
@@ -18,5 +18,15 @@ export const WEATHERAPI = {
   },
 };
 
+export const IPQUERY_API = {
+  URL: "https://api.ipquery.io",
+  ERROR_CODES: {
+    STATUS: {
+      EXCEEDED_RATE_LIMIT: 429,
+      INTERNAL: 500,
+    },
+  },
+};
+
 // https://docs.astro.build/en/guides/environment-variables/#default-environment-variables
 export const isDev = DEV;

--- a/legacy/github-jobs/src/services/ipquery/index.ts
+++ b/legacy/github-jobs/src/services/ipquery/index.ts
@@ -4,8 +4,9 @@ import {
   ServiceError,
   type PromiseWithError,
 } from "@lib/fetcher";
-import { IPQueryResponseSchema, type IpQueryResponse } from "./schema";
+import { IPQueryResponseSchema } from "./schema";
 import { IPQUERY_API } from "@/config";
+import type { LocationCoords } from "@/types";
 
 const ERROR_MESSAGES = {
   RATE_LIMIT_EXCEEDED: "Rate limit exceeded. Please try again in a few minutes",
@@ -13,9 +14,7 @@ const ERROR_MESSAGES = {
 };
 const IPQueryServiceError = new ServiceError("Geolocation[client]");
 
-export const getCurrentCoords = async (): PromiseWithError<
-  IpQueryResponse["location"]
-> => {
+export const getCurrentCoords = async (): PromiseWithError<LocationCoords> => {
   const [error, data] = await fetcher(`${IPQUERY_API.URL}?format=json`, {
     schema: IPQueryResponseSchema,
     serviceError: IPQueryServiceError,

--- a/legacy/github-jobs/src/services/ipquery/index.ts
+++ b/legacy/github-jobs/src/services/ipquery/index.ts
@@ -1,0 +1,43 @@
+import {
+  fetcher,
+  ResponseError,
+  ServiceError,
+  type PromiseWithError,
+} from "@lib/fetcher";
+import { IPQueryResponseSchema, type IpQueryResponse } from "./schema";
+import { IPQUERY_API } from "@/config";
+
+const ERROR_MESSAGES = {
+  RATE_LIMIT_EXCEEDED: "Rate limit exceeded. Please try again in a few minutes",
+  REMOTE_SERVER_ERROR: "Remote server error. Please try again later",
+};
+const IPQueryServiceError = new ServiceError("Geolocation[client]");
+
+export const getCurrentCoords = async (): PromiseWithError<
+  IpQueryResponse["location"]
+> => {
+  const [error, data] = await fetcher(`${IPQUERY_API.URL}?format=json`, {
+    schema: IPQueryResponseSchema,
+    serviceError: IPQueryServiceError,
+    timeout: 10_000,
+  });
+
+  if (error != null) {
+    if (error instanceof ResponseError) {
+      const statusError = error.res.status;
+
+      if (statusError === IPQUERY_API.ERROR_CODES.STATUS.EXCEEDED_RATE_LIMIT)
+        return [
+          IPQueryServiceError.generic(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED),
+        ];
+      if (statusError === IPQUERY_API.ERROR_CODES.STATUS.INTERNAL)
+        return [
+          IPQueryServiceError.generic(ERROR_MESSAGES.REMOTE_SERVER_ERROR),
+        ];
+    }
+
+    return [error];
+  }
+
+  return [null, data.location];
+};

--- a/legacy/github-jobs/src/services/ipquery/schema.ts
+++ b/legacy/github-jobs/src/services/ipquery/schema.ts
@@ -10,4 +10,3 @@ const LocationSchema = z.object({
 export const IPQueryResponseSchema = z.object({
   location: LocationSchema,
 });
-export type IpQueryResponse = z.infer<typeof IPQueryResponseSchema>;

--- a/legacy/github-jobs/src/services/ipquery/schema.ts
+++ b/legacy/github-jobs/src/services/ipquery/schema.ts
@@ -1,0 +1,14 @@
+import * as z from "zod";
+
+// NOTE: simplified to pick only the fields we need
+
+const LocationSchema = z.object({
+  zipcode: z.string(),
+  latitude: z.number(),
+  longitude: z.number(),
+});
+
+export const IPQueryResponseSchema = z.object({
+  location: LocationSchema,
+});
+export type IpQueryResponse = z.infer<typeof IPQueryResponseSchema>;

--- a/legacy/github-jobs/src/services/ipquery/schema.ts
+++ b/legacy/github-jobs/src/services/ipquery/schema.ts
@@ -3,7 +3,6 @@ import * as z from "zod";
 // NOTE: simplified to pick only the fields we need
 
 const LocationSchema = z.object({
-  zipcode: z.string(),
   latitude: z.number(),
   longitude: z.number(),
 });

--- a/legacy/github-jobs/src/services/jobs/mock.ts
+++ b/legacy/github-jobs/src/services/jobs/mock.ts
@@ -5,6 +5,8 @@ import jobsMock from "@/mocks/jobs.json";
 import type { Search } from "@/types";
 import type { JobsServiceResult } from "./client";
 
+// FIX: thumbnails are returning 404. update mocks
+
 const mockLocations = jobsMock.jobs_results.map(({ location }) => location);
 
 export const getMockedJobs = async (search: Search): JobsServiceResult => {

--- a/legacy/github-jobs/src/services/jobs/server.ts
+++ b/legacy/github-jobs/src/services/jobs/server.ts
@@ -15,6 +15,8 @@ import type { Search } from "@/types";
 
 const Schema = JobsResponseSchema.or(JobsErrorResponseSchema);
 
+// FIX: there is a 500 error in the response
+
 export const getJobs = async (
   search: Search,
 ): PromiseWithError<JobsResponse> => {

--- a/legacy/github-jobs/src/types.ts
+++ b/legacy/github-jobs/src/types.ts
@@ -1,5 +1,4 @@
 import type { Simplify } from "@hrc/type-utils";
-import type { LocationCoords } from "@lib/geolocation";
 
 export type ApplyOption = {
   title: string;
@@ -26,6 +25,7 @@ export type Search = {
   nextPageToken?: string;
 };
 
+export type LocationCoords = { latitude: number; longitude: number };
 export type LocationOptions = { zipCode: number } | { coords: LocationCoords };
 
 export type SetOptional<BaseType, Keys extends keyof BaseType> = Simplify<

--- a/legacy/github-jobs/src/utils/geolocation.ts
+++ b/legacy/github-jobs/src/utils/geolocation.ts
@@ -1,10 +1,13 @@
 import { getCurrentCoords } from "@lib/geolocation";
 import { searchLocation } from "@/services/geolocation/client";
+import { isDev } from "@/config";
 import type { PromiseWithError } from "@lib/fetcher";
 
 export const getLocationOption = async (
   location?: string,
 ): PromiseWithError<string> => {
+  if (isDev) return [null, "nowhereland"];
+
   if (location === "" || location == null) {
     const [coordsError, coords] = await getCurrentCoords({ timeout: 8000 });
 

--- a/legacy/github-jobs/src/utils/geolocation.ts
+++ b/legacy/github-jobs/src/utils/geolocation.ts
@@ -3,8 +3,6 @@ import { searchLocation } from "@/services/geolocation/client";
 import { isDev } from "@/config";
 import type { PromiseWithError } from "@lib/fetcher";
 
-// TODO: avoid calling services on dev mode
-
 export const getLocationOption = async (
   location?: string,
 ): PromiseWithError<string> => {
@@ -12,13 +10,9 @@ export const getLocationOption = async (
 
   if (location === "" || location == null) {
     const [coordsError, coords] = await getCurrentCoords();
-
     if (coordsError) return [coordsError];
 
-    if (coords.zipcode !== "") return [null, coords.zipcode];
-
     const [locationError, coordsLocation] = await searchLocation({ coords });
-
     if (locationError) return [locationError];
 
     return [null, coordsLocation];
@@ -31,7 +25,6 @@ export const getLocationOption = async (
 
   if (!isNaN(zipCode)) {
     const [locationError, zipLocation] = await searchLocation({ zipCode });
-
     if (locationError) return [locationError];
 
     return [null, zipLocation];

--- a/legacy/github-jobs/src/utils/geolocation.ts
+++ b/legacy/github-jobs/src/utils/geolocation.ts
@@ -1,7 +1,9 @@
-import { getCurrentCoords } from "@lib/geolocation";
+import { getCurrentCoords } from "@/services/ipquery";
 import { searchLocation } from "@/services/geolocation/client";
 import { isDev } from "@/config";
 import type { PromiseWithError } from "@lib/fetcher";
+
+// TODO: avoid calling services on dev mode
 
 export const getLocationOption = async (
   location?: string,
@@ -9,9 +11,11 @@ export const getLocationOption = async (
   if (isDev) return [null, "nowhereland"];
 
   if (location === "" || location == null) {
-    const [coordsError, coords] = await getCurrentCoords({ timeout: 8000 });
+    const [coordsError, coords] = await getCurrentCoords();
 
     if (coordsError) return [coordsError];
+
+    if (coords.zipcode !== "") return [null, coords.zipcode];
 
     const [locationError, coordsLocation] = await searchLocation({ coords });
 

--- a/libs/fetcher/TODO.md
+++ b/libs/fetcher/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+
+- part of description for `checkStatus` option must be:
+
+   ```txt
+   * **If `true`, you will be able to retrieve the response from the error by
+   * using `ResponseError` class.**
+   * **If `false`, be sure to use an schema that matches the expected error
+   * format.**
+   ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,9 +340,6 @@ importers:
       '@lib/fetcher':
         specifier: workspace:*
         version: link:../../libs/fetcher
-      '@lib/geolocation':
-        specifier: workspace:*
-        version: link:../../libs/geolocation
       '@lib/sass-utils':
         specifier: workspace:*
         version: link:../../libs/sass-utils


### PR DESCRIPTION
Use ipquery API instead of Geolocation API.

## Why?

I locally tested the app using Waterfox 6.6.9 and Gelocation API failed with the [`GeolocationPositionError.POSITION_UNAVAILABLE` code](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code) and the "Unknown error acquiring position" [error message](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/message) even if I enabled the geolocation permission and updated the `geo.provider.network.url` option in `about:config` page.

Other browsers works fine.

This change will prevent issues like this to any user.